### PR TITLE
Add automated example tests

### DIFF
--- a/Rev02/main.py
+++ b/Rev02/main.py
@@ -10,55 +10,69 @@ from data_loading import (
 from program_handlers import PROGRAM_HANDLERS
 
 
+def generate_program_pdf(
+    primary_data_path: str,
+    test_details_path: str,
+    output_pdf_path: str | Path,
+    is_gui: bool,
+) -> Path | None:
+    """Generate a PDF for a single program and return the file path."""
+    primary_data_file, test_details_file, pdf_output_path = get_file_paths(
+        primary_data_path,
+        test_details_path,
+        output_pdf_path,
+    )
+
+    test_metadata, transducer_details, channels_to_record, additional_info = (
+        load_test_information(test_details_file)
+    )
+
+    cleaned_data, active_channels = prepare_primary_data(
+        primary_data_file,
+        channels_to_record,
+    )
+
+    program_name = test_metadata.at["Program Name", 1]
+    handler = PROGRAM_HANDLERS.get(program_name)
+    if handler is None:
+        raise NotImplementedError(f"Program '{program_name}' is not supported")
+
+    return handler(
+        program_name,
+        test_metadata,
+        transducer_details,
+        active_channels,
+        cleaned_data,
+        additional_info,
+        pdf_output_path,
+        is_gui,
+    )
+
+
 def main() -> None:
     """Entry point for generating program PDFs."""
     try:
         parser = argparse.ArgumentParser(description="Process file paths.")
-        parser.add_argument("file_path1", type=str, help="Path to the primary data CSV file")
-        parser.add_argument("file_path2", type=str, help="Path to the test details CSV file")
-        parser.add_argument("file_path3", type=str, help="Path to the PDF Save Location")
+        parser.add_argument(
+            "file_path1", type=str, help="Path to the primary data CSV file"
+        )
+        parser.add_argument(
+            "file_path2", type=str, help="Path to the test details CSV file"
+        )
+        parser.add_argument(
+            "file_path3", type=str, help="Path to the PDF Save Location"
+        )
         parser.add_argument("is_gui", type=bool, help="GUI or not")
         args = parser.parse_args()
 
-        is_gui = args.is_gui
-
-        primary_data_file, test_details_file, pdf_output_path = get_file_paths(
-            args.file_path1, args.file_path2, args.file_path3
+        last_output = generate_program_pdf(
+            args.file_path1,
+            args.file_path2,
+            args.file_path3,
+            args.is_gui,
         )
 
-        # # For testing purposes, hardcode the file paths
-        # primary_data_file = "V:/Userdoc/R & D/DAQ_Station/jbradley/Attempt /CSV/4.0/4.0_Data_2-6-2025_9-47-6.csv"
-        # test_details_file = "V:/Userdoc/R & D/DAQ_Station/jbradley/Attempt /CSV/4.0/4.0_Test_Details_2-6-2025_9-47-6.csv"
-        # pdf_output_path = Path("V:/Userdoc/R & D/DAQ_Station/jbradley/Attempt /CSV/4.0")
-
-        # is_gui = True
-
-        test_metadata, transducer_details, channels_to_record, additional_info = load_test_information(
-            test_details_file
-        )
-
-        cleaned_data, active_channels = prepare_primary_data(
-            primary_data_file, channels_to_record
-        )
-
-        program_name = test_metadata.at["Program Name", 1]
-
-        handler = PROGRAM_HANDLERS.get(program_name)
-        if handler is None:
-            raise NotImplementedError(f"Program '{program_name}' is not supported")
-
-        last_output = handler(
-            program_name,
-            test_metadata,
-            transducer_details,
-            active_channels,
-            cleaned_data,
-            additional_info,
-            pdf_output_path,
-            is_gui,
-        )
-
-        if not is_gui and last_output:
+        if not args.is_gui and last_output:
             doc = fitz.open(last_output)
             page = doc.load_page(0)
             zoom_factor = 3

--- a/Rev02/pdf_helpers.py
+++ b/Rev02/pdf_helpers.py
@@ -1,3 +1,4 @@
+import os
 import matplotlib.pyplot as plt
 import io
 from reportlab.lib import colors
@@ -6,6 +7,7 @@ import pandas as pd
 from reportlab.pdfgen import canvas
 from reportlab.lib.pagesizes import landscape, A4
 from reportlab.lib.utils import ImageReader
+
 
 def insert_plot_and_logo(figure, pdf, is_gui):
     """
@@ -19,14 +21,30 @@ def insert_plot_and_logo(figure, pdf, is_gui):
         io.BytesIO: A binary stream containing the rendered PNG.
     """
     png_figure = io.BytesIO()
-    figure.savefig(png_figure, format='PNG', bbox_inches='tight', dpi=500)
+    figure.savefig(png_figure, format="PNG", bbox_inches="tight", dpi=500)
     png_figure.seek(0)
     plt.close(figure)
     fig_img = ImageReader(png_figure)
-    pdf.drawImage(fig_img, 16, 67.5, 598, 416.5, preserveAspectRatio=False, mask='auto')
-    image_path = 'V:/Userdoc/R & D/Logos/R&D_Page_2.png' if is_gui else '/var/opt/codesys/PlcLogic/R&D_Page_2.png'
-    pdf.drawImage(image_path, 629, 515, 197, 65, preserveAspectRatio=True, mask='auto')
+    pdf.drawImage(fig_img, 16, 67.5, 598, 416.5, preserveAspectRatio=False, mask="auto")
+    image_path = (
+        "V:/Userdoc/R & D/Logos/R&D_Page_2.png"
+        if is_gui
+        else "/var/opt/codesys/PlcLogic/R&D_Page_2.png"
+    )
+    if os.path.exists(image_path):
+        pdf.drawImage(
+            image_path,
+            629,
+            515,
+            197,
+            65,
+            preserveAspectRatio=True,
+            mask="auto",
+        )
+    else:
+        print(f"Warning: logo image not found at {image_path}, skipping logo")
     pdf.save()
+
 
 def draw_bounding_box(pdf_canvas, x, y, width, height):
     """
@@ -43,11 +61,21 @@ def draw_bounding_box(pdf_canvas, x, y, width, height):
     pdf_canvas.rect(x, y, width, height)
 
 
-def draw_text_on_pdf(pdf_canvas, text, x, y, font="Helvetica", colour='black', size=10, left_aligned=False, replace_empty=False):
+def draw_text_on_pdf(
+    pdf_canvas,
+    text,
+    x,
+    y,
+    font="Helvetica",
+    colour="black",
+    size=10,
+    left_aligned=False,
+    replace_empty=False,
+):
     """
     Draw text onto the PDF canvas, with options for alignment (left or centre).
-    
-    If the text is a Timestamp, it can optionally preserve only the date (dd/mm/yyyy) 
+
+    If the text is a Timestamp, it can optionally preserve only the date (dd/mm/yyyy)
     or include milliseconds precision to 3 decimal places.
 
     Parameters:
@@ -84,32 +112,45 @@ def draw_text_on_pdf(pdf_canvas, text, x, y, font="Helvetica", colour='black', s
     pdf_canvas.drawString(draw_x, draw_y, text)
     pdf_canvas.setFillColor(colors.black)  # Reset to black afterwards
 
+
 def draw_layout_boxes(pdf):
     PDF_LAYOUT_BOXES = [
-        (15, 515, 600, 65),         # Info Top Left
-        (15, 66.5, 600, 418.5),     # Graph
-        (15, 15, 600, 51.5),        # Graph Index
-        (630, 271.66, 197, 17.5),   # Test Pressures
-        (630, 225.83, 197, 35),        # Breakout Torque
-        (630, 35, 197, 180),        # 3rd Party Stamp
-        (630, 300, 197, 185)        # Info Right
+        (15, 515, 600, 65),  # Info Top Left
+        (15, 66.5, 600, 418.5),  # Graph
+        (15, 15, 600, 51.5),  # Graph Index
+        (630, 271.66, 197, 17.5),  # Test Pressures
+        (630, 225.83, 197, 35),  # Breakout Torque
+        (630, 35, 197, 180),  # 3rd Party Stamp
+        (630, 300, 197, 185),  # Info Right
     ]
     for box in PDF_LAYOUT_BOXES:
         draw_bounding_box(pdf, *box)
 
+
 def draw_headers(pdf, test_metadata, cleaned_data, light_blue):
-    draw_text_on_pdf(pdf,
-        f"{test_metadata.at['Test Section Number', 1]} {test_metadata.at['Test Name', 1]}",
-        315, 500, font="Helvetica-Bold", size=16)
     draw_text_on_pdf(
         pdf,
-        cleaned_data.at[0, 'Datetime'].strftime('%d/%m/%Y'),
-        487.5, 539.375,
-        colour=light_blue,
-        left_aligned=True
+        f"{test_metadata.at['Test Section Number', 1]} {test_metadata.at['Test Name', 1]}",
+        315,
+        500,
+        font="Helvetica-Bold",
+        size=16,
     )
-    draw_text_on_pdf(pdf, "Data Recording Equipment Used", 728.5, 475, "Helvetica-Bold", size=12)
-    draw_text_on_pdf(pdf, "3rd Party Stamp and Date", 728.5, 45, "Helvetica-Bold", size=12)
+    draw_text_on_pdf(
+        pdf,
+        cleaned_data.at[0, "Datetime"].strftime("%d/%m/%Y"),
+        487.5,
+        539.375,
+        colour=light_blue,
+        left_aligned=True,
+    )
+    draw_text_on_pdf(
+        pdf, "Data Recording Equipment Used", 728.5, 475, "Helvetica-Bold", size=12
+    )
+    draw_text_on_pdf(
+        pdf, "3rd Party Stamp and Date", 728.5, 45, "Helvetica-Bold", size=12
+    )
+
 
 def prepare_transducer_dataframe(transducer_details, active_channels):
     empty_rows = pd.DataFrame([["", ""]] * 14)
@@ -118,39 +159,59 @@ def prepare_transducer_dataframe(transducer_details, active_channels):
     used_transducers = pd.concat([used_transducers, empty_rows], ignore_index=True)
     return used_transducers
 
+
 def build_static_text_positions(test_metadata, light_blue, black):
     return [
         # Left column
         (20, 571.875, "Test Procedure Reference", black, False),
-        (140, 571.875, test_metadata.at['Test Procedure Reference', 1], light_blue, True),
+        (
+            140,
+            571.875,
+            test_metadata.at["Test Procedure Reference", 1],
+            light_blue,
+            True,
+        ),
         (20, 555.625, "Unique No.", black, False),
-        (140, 555.625, test_metadata.at['Unique Number', 1], light_blue, True),
+        (140, 555.625, test_metadata.at["Unique Number", 1], light_blue, True),
         (20, 539.375, "R&D Reference", black, False),
-        (140, 539.375, test_metadata.at['R&D Reference', 1], light_blue, True),
+        (140, 539.375, test_metadata.at["R&D Reference", 1], light_blue, True),
         (20, 523.125, "Valve Description", black, False),
-        (140, 523.125, test_metadata.at['Valve Description', 1], light_blue, True),
+        (140, 523.125, test_metadata.at["Valve Description", 1], light_blue, True),
         # Right column
         (402.5, 571.875, "Job No.", black, False),
-        (487.5, 571.875, test_metadata.at['Job Number', 1], light_blue, True),
+        (487.5, 571.875, test_metadata.at["Job Number", 1], light_blue, True),
         (402.5, 555.625, "Test Description", black, False),
-        (487.5, 555.625, test_metadata.at['Test Section Number', 1], light_blue, True),
+        (487.5, 555.625, test_metadata.at["Test Section Number", 1], light_blue, True),
         (402.5, 539.375, "Test Date", black, False),
         (402.5, 523.125, "Valve Drawing No.", black, False),
-        (487.5, 523.125, test_metadata.at['Valve Drawing Number', 1], light_blue, True),
+        (487.5, 523.125, test_metadata.at["Valve Drawing Number", 1], light_blue, True),
         # Pressures & torques
         (635, 280.41, "Test Pressure", black, False),
         (725, 280.41, f"{test_metadata.at['Test Pressure', 1]} psi", light_blue, True),
         (635, 252.08, "Breakout Torque", black, False),
-        (725, 252.08, f"{test_metadata.at['Breakout Torque', 1]} ft.lbs", light_blue, True),
+        (
+            725,
+            252.08,
+            f"{test_metadata.at['Breakout Torque', 1]} ft.lbs",
+            light_blue,
+            True,
+        ),
         (635, 234.58, "Running Torque", black, False),
-        (725, 234.58, f"{test_metadata.at['Running Torque', 1]} ft.lbs", light_blue, True),
+        (
+            725,
+            234.58,
+            f"{test_metadata.at['Running Torque', 1]} ft.lbs",
+            light_blue,
+            True,
+        ),
         (635, 457.5, "Data Logger", black, False),
-        (725, 457.5, test_metadata.at['Data Logger', 1], light_blue, True),
+        (725, 457.5, test_metadata.at["Data Logger", 1], light_blue, True),
         (635, 442.5, "Serial No.", black, False),
-        (725, 442.5, test_metadata.at['Serial Number', 1], light_blue, True),
+        (725, 442.5, test_metadata.at["Serial Number", 1], light_blue, True),
         (635, 427.5, "Transducers", black, False),
         (635, 367.5, "Gauges", black, False),
     ]
+
 
 def build_transducer_and_gauge_positions(used_transducers, light_blue):
     positions = []
@@ -164,168 +225,190 @@ def build_transducer_and_gauge_positions(used_transducers, light_blue):
         positions.append((x, y, used_transducers.iat[i, 1], light_blue, False))
     return positions
 
-def build_torque_and_stamp_positions(transducer_details, test_metadata, light_blue, black):
+
+def build_torque_and_stamp_positions(
+    transducer_details, test_metadata, light_blue, black
+):
     return [
         (635, 307.5, "Torque Transducer", black, False),
-        (725, 307.5, transducer_details.at['Torque', 1], light_blue, True),
+        (725, 307.5, transducer_details.at["Torque", 1], light_blue, True),
         (635, 22.5, "Operative:", black, False),
-        (685, 22.5, test_metadata.at['Operative', 1], light_blue, False),
+        (685, 22.5, test_metadata.at["Operative", 1], light_blue, False),
     ]
 
-def build_program_specific_info(program_name, additional_info_indicies, additional_info_value, cleaned_data, black, light_blue):
+
+def build_program_specific_info(
+    program_name,
+    additional_info_indicies,
+    additional_info_value,
+    cleaned_data,
+    black,
+    light_blue,
+):
     positions = []
 
-    #------------------------------------------------------------------------------
+    # ------------------------------------------------------------------------------
     # Program = Holds
-    #------------------------------------------------------------------------------
+    # ------------------------------------------------------------------------------
 
     if program_name == "Holds":
 
         indices = additional_info_indicies.iloc[0]
-        main_ch = additional_info_value.iloc[0]['Main Channel']
+        main_ch = additional_info_value.iloc[0]["Main Channel"]
         for label, ypos, col in [
-            ("Start of Stabilisation", 56.5, 'Start of Stabilisation'),
-            ("Start of Hold", 41.25, 'Start of Hold'),
-            ("End of Hold", 25, 'End of Hold')
+            ("Start of Stabilisation", 56.5, "Start of Stabilisation"),
+            ("Start of Hold", 41.25, "Start of Hold"),
+            ("End of Hold", 25, "End of Hold"),
         ]:
             idx = indices[col]
-            if idx != '':
-                time = cleaned_data.at[idx, 'Datetime'].strftime('%d/%m/%Y %H:%M:%S')
-                psi  = int(cleaned_data.at[idx, main_ch])
-                temp = cleaned_data.at[idx, 'Ambient Temperature']
-                positions.extend([
-                    (20, ypos, label, black, False),
-                    (120, ypos,
-                        f"{time}   {psi} psi   {temp}\u00B0C",
-                        light_blue, False
-                    )
-                ])
+            if idx != "":
+                time = cleaned_data.at[idx, "Datetime"].strftime("%d/%m/%Y %H:%M:%S")
+                psi = int(cleaned_data.at[idx, main_ch])
+                temp = cleaned_data.at[idx, "Ambient Temperature"]
+                positions.extend(
+                    [
+                        (20, ypos, label, black, False),
+                        (
+                            120,
+                            ypos,
+                            f"{time}   {psi} psi   {temp}\u00b0C",
+                            light_blue,
+                            False,
+                        ),
+                    ]
+                )
 
-    #------------------------------------------------------------------------------
+    # ------------------------------------------------------------------------------
     # Program = Atmospheric Breakouts
-    #------------------------------------------------------------------------------
+    # ------------------------------------------------------------------------------
 
     elif program_name == "Atmospheric Breakouts":
-        
+
         for i in range(3):
             val = additional_info_value.iat[i, 1]
-            if val not in ['', 0, 0.0]:
+            if val not in ["", 0, 0.0]:
+                positions.append((20, 56.5 - i * 15, f"Breakout {i+1}", black, False))
                 positions.append(
-                    (20, 56.5 - i*15, f"Breakout {i+1}", black, False)
-                )
-                positions.append(
-                    (75, 56.5 - i*15, f"{val} ft.lbs", light_blue, False)
+                    (75, 56.5 - i * 15, f"{val} ft.lbs", light_blue, False)
                 )
 
-    #------------------------------------------------------------------------------
+    # ------------------------------------------------------------------------------
     # Program = Atmospheric Cyclic
-    #------------------------------------------------------------------------------
+    # ------------------------------------------------------------------------------
 
     elif program_name == "Atmospheric Cyclic":
-        
+
         for i in range(len(additional_info_value.index)):
             val = additional_info_value.iat[i, 1]
-            if val not in ['', 0, 0.0]:
+            if val not in ["", 0, 0.0]:
+                positions.append((20, 56.5 - i * 15, f"Breakout {i+1}", black, False))
                 positions.append(
-                    (20, 56.5 - i*15, f"Breakout {i+1}", black, False)
-                )
-                positions.append(
-                    (75, 56.5 - i*15, f"{val} ft.lbs", light_blue, False)
+                    (75, 56.5 - i * 15, f"{val} ft.lbs", light_blue, False)
                 )
 
-    #------------------------------------------------------------------------------
+    # ------------------------------------------------------------------------------
     # Program = Dynamic Cycles PR2
-    #------------------------------------------------------------------------------
+    # ------------------------------------------------------------------------------
 
     elif program_name == "Dynamic Cycles PR2":
 
         for i in range(3):
             val = additional_info_value.iat[i, 1]
-            if val not in ['', 0, 0.0]:
+            if val not in ["", 0, 0.0]:
+                positions.append((20, 56.5 - i * 15, f"Breakout {i+1}", black, False))
                 positions.append(
-                    (20, 56.5 - i*15, f"Breakout {i+1}", black, False)
-                )
-                positions.append(
-                    (75, 56.5 - i*15, f"{val} ft.lbs", light_blue, False)
+                    (75, 56.5 - i * 15, f"{val} ft.lbs", light_blue, False)
                 )
 
-    #------------------------------------------------------------------------------
+    # ------------------------------------------------------------------------------
     # Program = Dynamic Cycles Petrobras
-    #------------------------------------------------------------------------------
+    # ------------------------------------------------------------------------------
 
     elif program_name == "Dynamic Cycles Petrobras":
 
         for i in range(3):
             val = additional_info_value.iat[i, 1]
-            if val not in ['', 0, 0.0]:
+            if val not in ["", 0, 0.0]:
+                positions.append((20, 56.5 - i * 15, f"Breakout {i+1}", black, False))
                 positions.append(
-                    (20, 56.5 - i*15, f"Breakout {i+1}", black, False)
-                )
-                positions.append(
-                    (75, 56.5 - i*15, f"{val} ft.lbs", light_blue, False)
+                    (75, 56.5 - i * 15, f"{val} ft.lbs", light_blue, False)
                 )
 
-    #------------------------------------------------------------------------------
+    # ------------------------------------------------------------------------------
     # Program = Pulse Cycles
-    #------------------------------------------------------------------------------
+    # ------------------------------------------------------------------------------
 
     elif program_name == "Pulse Cycles":
 
         for i in range(len(additional_info_value.index)):
             val = additional_info_value.iat[i, 1]
-            if val not in ['', 0, 0.0]:
+            if val not in ["", 0, 0.0]:
+                positions.append((20, 56.5 - i * 15, f"Breakout {i+1}", black, False))
                 positions.append(
-                    (20, 56.5 - i*15, f"Breakout {i+1}", black, False)
+                    (75, 56.5 - i * 15, f"{val} ft.lbs", light_blue, False)
                 )
-                positions.append(
-                    (75, 56.5 - i*15, f"{val} ft.lbs", light_blue, False)
-                )
-    #------------------------------------------------------------------------------
+    # ------------------------------------------------------------------------------
     # Program = Signatures
-    #------------------------------------------------------------------------------
+    # ------------------------------------------------------------------------------
 
     elif program_name == "Signatures":
 
         for i in range(len(additional_info_value.index)):
             val = additional_info_value.iat[i, 1]
-            if val not in ['', 0, 0.0]:
+            if val not in ["", 0, 0.0]:
+                positions.append((20, 56.5 - i * 15, f"Breakout {i+1}", black, False))
                 positions.append(
-                    (20, 56.5 - i*15, f"Breakout {i+1}", black, False)
-                )
-                positions.append(
-                    (75, 56.5 - i*15, f"{val} ft.lbs", light_blue, False)
+                    (75, 56.5 - i * 15, f"{val} ft.lbs", light_blue, False)
                 )
 
-    #------------------------------------------------------------------------------
+    # ------------------------------------------------------------------------------
     # Program = Open-Close
-    #------------------------------------------------------------------------------
+    # ------------------------------------------------------------------------------
 
     elif program_name == "Open-Close":
-    
+
         for i in range(len(additional_info_value.index)):
             val = additional_info_value.iat[i, 1]
-            if val not in ['', 0, 0.0]:
+            if val not in ["", 0, 0.0]:
+                positions.append((20, 56.5 - i * 15, f"Breakout {i+1}", black, False))
                 positions.append(
-                    (20, 56.5 - i*15, f"Breakout {i+1}", black, False)
-                )
-                positions.append(
-                    (75, 56.5 - i*15, f"{val} ft.lbs", light_blue, False)
+                    (75, 56.5 - i * 15, f"{val} ft.lbs", light_blue, False)
                 )
 
-    #------------------------------------------------------------------------------
+    # ------------------------------------------------------------------------------
     # Program = Number of Turns
-    #------------------------------------------------------------------------------
+    # ------------------------------------------------------------------------------
 
     elif program_name == "Number Of Turns":
         pass
-    
+
     return positions
+
 
 def draw_all_text(pdf, pdf_text_positions):
     for x, y, text, colour, replace_empty in pdf_text_positions:
-        draw_text_on_pdf(pdf, text, x, y, colour=colour, size=10, left_aligned=True, replace_empty=replace_empty)
+        draw_text_on_pdf(
+            pdf,
+            text,
+            x,
+            y,
+            colour=colour,
+            size=10,
+            left_aligned=True,
+            replace_empty=replace_empty,
+        )
 
-def draw_test_details(test_metadata, transducer_details, active_channels, cleaned_data, pdf_output_path, additional_info_indicies, additional_info_value, program_name):
+
+def draw_test_details(
+    test_metadata,
+    transducer_details,
+    active_channels,
+    cleaned_data,
+    pdf_output_path,
+    additional_info_indicies,
+    additional_info_value,
+    program_name,
+):
     pdf = canvas.Canvas(str(pdf_output_path), pagesize=landscape(A4))
     pdf.setStrokeColor(colors.black)
     draw_layout_boxes(pdf)
@@ -334,8 +417,19 @@ def draw_test_details(test_metadata, transducer_details, active_channels, cleane
     draw_headers(pdf, test_metadata, cleaned_data, light_blue)
     used_transducers = prepare_transducer_dataframe(transducer_details, active_channels)
     pdf_text_positions = build_static_text_positions(test_metadata, light_blue, black)
-    pdf_text_positions += build_transducer_and_gauge_positions(used_transducers, light_blue)
-    pdf_text_positions += build_torque_and_stamp_positions(transducer_details, test_metadata, light_blue, black)
-    pdf_text_positions += build_program_specific_info(program_name, additional_info_indicies, additional_info_value, cleaned_data, black, light_blue)
+    pdf_text_positions += build_transducer_and_gauge_positions(
+        used_transducers, light_blue
+    )
+    pdf_text_positions += build_torque_and_stamp_positions(
+        transducer_details, test_metadata, light_blue, black
+    )
+    pdf_text_positions += build_program_specific_info(
+        program_name,
+        additional_info_indicies,
+        additional_info_value,
+        cleaned_data,
+        black,
+        light_blue,
+    )
     draw_all_text(pdf, pdf_text_positions)
     return pdf

--- a/tests/test_example_data.py
+++ b/tests/test_example_data.py
@@ -1,0 +1,29 @@
+import os
+import sys
+from pathlib import Path
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "Rev02"))
+from main import generate_program_pdf
+
+EXAMPLE_ROOT = Path("Example Data/Hydraulic")
+
+
+@pytest.mark.parametrize(
+    "program_dir",
+    [
+        "Atmospheric Breakouts",
+        "Dynamic Cycles Petrobras",
+        "Dynamic Cycles PR2",
+        "Holds",
+        "Open-Close",
+    ],
+)
+def test_generate_pdf(program_dir, tmp_path):
+    data_dir = EXAMPLE_ROOT / program_dir
+    primary = data_dir / "primary_data.csv"
+    details = data_dir / "test_details.csv"
+    output_path = tmp_path
+    result = generate_program_pdf(str(primary), str(details), str(output_path), False)
+    assert result is not None
+    assert os.path.exists(result)


### PR DESCRIPTION
## Summary
- make `generate_program_pdf` callable for tests
- skip logo when not present in `pdf_helpers`
- add pytest suite that runs on example CSV data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840257bc4d4832daa4eb703e6200031