### PR TITLE
Add example data CLI flag for easier testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# R&D AutoChart Generation
+
+This repository contains utilities for generating PDF charts from CSV test data.
+
+## Running with custom data
+
+On the Raspberry Pi or any system with Python and the required libraries
+installed, you can run the program by providing the paths to the required
+files:
+
+```bash
+python Rev02/main.py <primary_data.csv> <test_details.csv> <output_dir> <True|False>
+```
+
+`True` enables GUI related behaviour, while `False` runs the program headless.
+
+## Quick testing with example data
+
+For development purposes a collection of sample CSV files is included under the
+`Example Data` directory.  The `main.py` script now supports a convenient
+`--example` flag to run directly against these datasets.
+
+To test using the `Holds` example, run:
+
+```bash
+python Rev02/main.py --example Holds
+```
+
+Available example names correspond to the folders under
+`Example Data/Hydraulic` (e.g. `Atmospheric Breakouts`, `Dynamic Cycles PR2`,
+`Dynamic Cycles Petrobras`, `Holds`, `Open-Close`).  When `--example` is
+provided the script automatically loads the matching `primary_data.csv` and
+`test_details.csv` and writes the output PDF to the same folder.
+
+The original command line behaviour using explicit file paths continues to
+work as before.

--- a/Rev02/main.py
+++ b/Rev02/main.py
@@ -2,6 +2,13 @@ import argparse
 from pathlib import Path
 import fitz
 
+
+def str2bool(value: str) -> bool:
+    """Convert a string to boolean for argument parsing."""
+    if isinstance(value, bool):
+        return value
+    return value.lower() in {"true", "1", "yes", "y"}
+
 from data_loading import (
     get_file_paths,
     load_test_information,
@@ -14,17 +21,61 @@ def main() -> None:
     """Entry point for generating program PDFs."""
     try:
         parser = argparse.ArgumentParser(description="Process file paths.")
-        parser.add_argument("file_path1", type=str, help="Path to the primary data CSV file")
-        parser.add_argument("file_path2", type=str, help="Path to the test details CSV file")
-        parser.add_argument("file_path3", type=str, help="Path to the PDF Save Location")
-        parser.add_argument("is_gui", type=bool, help="GUI or not")
+        parser.add_argument(
+            "file_path1",
+            nargs="?",
+            type=str,
+            help="Path to the primary data CSV file",
+        )
+        parser.add_argument(
+            "file_path2",
+            nargs="?",
+            type=str,
+            help="Path to the test details CSV file",
+        )
+        parser.add_argument(
+            "file_path3",
+            nargs="?",
+            type=str,
+            help="Path to the PDF save location",
+        )
+        parser.add_argument(
+            "is_gui",
+            nargs="?",
+            type=str,
+            default="False",
+            help="GUI or not",
+        )
+        parser.add_argument(
+            "--example",
+            type=str,
+            help=(
+                "Name of example dataset to load from 'Example Data/Hydraulic'. "
+                "When provided, file path arguments are ignored."
+            ),
+        )
         args = parser.parse_args()
 
-        is_gui = args.is_gui
+        is_gui = str2bool(args.is_gui)
 
-        primary_data_file, test_details_file, pdf_output_path = get_file_paths(
-            args.file_path1, args.file_path2, args.file_path3
-        )
+        if args.example:
+            example_dir = (
+                Path(__file__).resolve().parent.parent
+                / "Example Data"
+                / "Hydraulic"
+                / args.example
+            )
+            primary_data_file = example_dir / "primary_data.csv"
+            test_details_file = example_dir / "test_details.csv"
+            pdf_output_path = example_dir
+        else:
+            if not all([args.file_path1, args.file_path2, args.file_path3]):
+                parser.error(
+                    "file_path1, file_path2 and file_path3 are required unless --example is used"
+                )
+            primary_data_file, test_details_file, pdf_output_path = get_file_paths(
+                args.file_path1, args.file_path2, args.file_path3
+            )
 
         # # For testing purposes, hardcode the file paths
         # primary_data_file = "V:/Userdoc/R & D/DAQ_Station/jbradley/Attempt /CSV/4.0/4.0_Data_2-6-2025_9-47-6.csv"


### PR DESCRIPTION
## Summary
- add `--example` flag to `main.py` for running against bundled example data
- parse boolean arguments reliably
- document new usage in README

## Testing
- `pip install -r Rev02/requirements.txt`
- `python Rev02/main.py --example Holds` *(fails: Cannot open resource "/var/opt/codesys/PlcLogic/R&D_Page_2.png")*

------
https://chatgpt.com/codex/tasks/task_e_684029fba814832d8fec0befb28337f2